### PR TITLE
Limited folders where the configuration file is searched

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -4,7 +4,7 @@ addin_lint <- function() {
     return("Current source has no path. Please save before continue")
   }
 
-  config_file <- (get("find_config", asNamespace("lintr")))(filename$path)
+  config_file <- lintr:::find_config(filename$path)
   if (length(config_file) == 0) {
     config_linters <- NULL
   } else {

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -69,7 +69,7 @@ parse_exclusions <- function(file, exclude = settings$exclude,
   sort(unique(c(exclusions, which(rex::re_matches(lines, exclude)))))
 }
 
-normalize_exclusions <- function(x, normalize_path=TRUE, dir_prefix = NULL) {
+normalize_exclusions <- function(x, dir_prefix = NULL) {
   if (is.null(x) || length(x) <= 0) {
     return(list())
   }
@@ -101,12 +101,13 @@ normalize_exclusions <- function(x, normalize_path=TRUE, dir_prefix = NULL) {
   # Paths to excluded files are specified relative-to the package- or
   # directory-root (when running lint_dir or lint_package)
   if (!is.null(dir_prefix)) {
-    names(x) <- file.path(dir_prefix, names(x))
+    relative_paths <- !is_absolute_path(names(x))
+    names(x)[relative_paths] <- file.path(dir_prefix, names(x)[relative_paths])
   }
-  if (normalize_path) {
-    x <- x[file.exists(names(x))]       # remove exclusions for non-existing files
-    names(x) <- normalizePath(names(x)) # get full path for remaining files
-  }
+
+  x <- x[file.exists(names(x))]       # remove exclusions for non-existing files
+  names(x) <- normalizePath(names(x)) # get full path for remaining files
+
 
   remove_line_duplicates(
     remove_file_duplicates(

--- a/R/lint.R
+++ b/R/lint.R
@@ -233,7 +233,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ..., exclusions = lis
   read_settings(path)
   on.exit(clear_settings, add = TRUE)
 
-  exclusions <- normalize_exclusions(c(exclusions, settings$exclusions), FALSE)
+  exclusions <- normalize_exclusions(c(exclusions, settings$exclusions))
 
   lints <- lint_dir(file.path(path, c("R", "tests", "inst")), relative_path = FALSE, exclusions = exclusions, parse_settings = FALSE, ...)
 
@@ -276,19 +276,6 @@ is_root <- function(path) {
 
 has_config <- function(path, config) {
   file.exists(file.path(path, config))
-}
-
-find_config2 <- function(path) {
-  config <- basename(getOption("lintr.linter_file"))
-  path <- normalizePath(path, mustWork = FALSE)
-
-  while (!has_config(path, config)) {
-    path <- dirname(path)
-    if (is_root(path)) {
-      return(character())
-    }
-  }
-  return(file.path(path, config))
 }
 
 pkg_name <- function(path = find_package()) {

--- a/R/settings.R
+++ b/R/settings.R
@@ -84,20 +84,6 @@ find_config <- function(filename) {
     return(linter_config)
   }
 
-  ## next check for a file higher directories
-  linter_config <- find_config2(path)
-  if (isTRUE(file.exists(linter_config))) {
-    return(linter_config)
-  }
-
-  ## next check for a file in the user directory
-  # cf: rstudio@bc9b6a5 SessionRSConnect.R#L32
-  home_dir <- Sys.getenv("HOME", unset = "~")
-  linter_config <- file.path(home_dir, linter_file)
-  if (isTRUE(file.exists(linter_config))) {
-    return(linter_config)
-  }
-
   NULL
 }
 

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -176,9 +176,6 @@ test_that("it normalizes file paths, removing non-existing files", {
   t3 <- list(); t3[[c]] <- 5:15
   res <- list(); res[[a]] <- 1:10; res[[normalizePath(c)]] <- 5:15
   expect_equal(normalize_exclusions(c(t1, t2, t3)), res)
-
-  res <- list(); res[[a]] <- 1:10; res[["notafile"]] <- 5:15; res[[c]] <- 5:15
-  expect_equal(normalize_exclusions(c(t1, t2, t3), normalize_path=FALSE), res)
 })
 
 unlink(c(a, b, c))

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -14,8 +14,8 @@ test_that("lint() results do not depend on the working directory", {
   pkg_path <- file.path("dummy_packages", "assignmentLinter")
 
   # put a .lintr in the package root that excludes the first line of `R/jkl.R`
-  config_path <- file.path(pkg_path, ".lintr")
-  config_string <- "exclusions: list('R/jkl.R' = 1)\n"
+  config_path <- file.path(pkg_path, "R", ".lintr")
+  config_string <- "exclusions: list('jkl.R' = 1)\n"
   cat(config_string, file = config_path)
   on.exit(unlink(config_path))
 
@@ -80,11 +80,11 @@ test_that("lint() results do not depend on the position of the .lintr", {
   expected_lines <- "mno = 789"
 
   lints_with_config_at_pkg_root <- withr::with_dir(
-    pkg_path,
+    file.path(pkg_path, "R"),
     lint_with_config(
       config_path = ".lintr",
-      config_string = "exclusions: list('R/jkl.R' = 1)\n",
-      filename = file.path("R", "jkl.R")
+      config_string = "exclusions: list('jkl.R' = 1)\n",
+      filename = "jkl.R"
     )
   )
 


### PR DESCRIPTION
- Changed `find_config` so that lint functions only search for a configuration file in the parent folder of the file or the root of the project that is given as input.

- Removed the parameter `normalize_path` from `normalize_exclusions` since there was only one instance where the default argument was not used. Moreover, in that instance the input exclusions paths are absolute paths.

- Changed `normalize_exclusions` to prevent adding a prefix when the paths in the exclusions are absolute paths.