### PR TITLE
Adjusted handling of path prefixes and .lintr to pass tests

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: with_defaults(line_length_linter(120))
-exclusions: list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R", "tests/testthat/exclusions-test")
+exclusions: list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: with_defaults(line_length_linter(120))
-exclusions: list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")
+exclusions: list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R", "tests/testthat/exclusions-test")

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -101,7 +101,8 @@ normalize_exclusions <- function(x, normalize_path=TRUE, dir_prefix = NULL) {
   # Paths to excluded files are specified relative-to the package- or
   # directory-root (when running lint_dir or lint_package)
   if (!is.null(dir_prefix)) {
-    names(x) <- file.path(dir_prefix, names(x))
+    relative_paths <- !is_absolute_path(names(x))
+    names(x)[relative_paths] <- file.path(dir_prefix, names(x)[relative_paths])
   }
   if (normalize_path) {
     x <- x[file.exists(names(x))]       # remove exclusions for non-existing files

--- a/R/lint.R
+++ b/R/lint.R
@@ -233,7 +233,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ..., exclusions = lis
   read_settings(path)
   on.exit(clear_settings, add = TRUE)
 
-  exclusions <- normalize_exclusions(c(exclusions, settings$exclusions), FALSE)
+  exclusions <- normalize_exclusions(c(exclusions, settings$exclusions), dir_prefix = path)
 
   lints <- lint_dir(file.path(path, c("R", "tests", "inst")), relative_path = FALSE, exclusions = exclusions, parse_settings = FALSE, ...)
 

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -174,11 +174,25 @@ test_that("it normalizes file paths, removing non-existing files", {
   t1 <- list(); t1[[a]] <- 1:10
   t2 <- list(); t2[["notafile"]] <- 5:15
   t3 <- list(); t3[[c]] <- 5:15
+  t4 <- list(); t4[[basename(c)]] <- 5:15
+  pkg_root <- "../.."
+  prefix <- file.path("tests", "testthat")
   res <- list(); res[[a]] <- 1:10; res[[normalizePath(c)]] <- 5:15
   expect_equal(normalize_exclusions(c(t1, t2, t3)), res)
+  expect_equal(withr::with_dir(pkg_root, normalize_exclusions(c(t1, t2, t4),
+                                                              dir_prefix=prefix)),
+               res)
 
   res <- list(); res[[a]] <- 1:10; res[["notafile"]] <- 5:15; res[[c]] <- 5:15
   expect_equal(normalize_exclusions(c(t1, t2, t3), normalize_path=FALSE), res)
+
+  res <- list(); res[[a]] <- 1:10; res[[file.path(prefix, "notafile")]] <- 5:15
+  res[[file.path(prefix, basename(c))]] <- 5:15
+  expect_equal(withr::with_dir(pkg_root,
+                               normalize_exclusions(c(t1, t2, t4),
+                                                    normalize_path=FALSE,
+                                                    dir_prefix=prefix)),
+               res)
 })
 
 unlink(c(a, b, c))

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -201,7 +201,7 @@ context("exclude")
 test_that("it excludes properly", {
   read_settings(NULL)
 
-  t1 <- lint("exclusions-test")
+  t1 <- lint("exclusions-test", exclusions = list())
 
   expect_equal(length(t1), 2)
 
@@ -216,7 +216,7 @@ test_that("it excludes properly", {
   cache_path <- file.path(tempdir(), "lintr_cache")
   clear_cache("exclusions-test", cache_path)
   for (info in sprintf("caching: pass %s", 1:4)) {
-    t4 <- lint("exclusions-test", cache = cache_path)
+    t4 <- lint("exclusions-test", cache = cache_path, exclusions = list())
 
     expect_equal(length(t4), 2, info = info)
   }

--- a/tests/testthat/test-expect_lint.R
+++ b/tests/testthat/test-expect_lint.R
@@ -35,7 +35,8 @@ test_that("single check", {
 })
 
 test_that("multiple checks", {
-  expect_success(expect_lint(file = "exclusions-test", checks = as.list(rep(msg, 6L)), linters = linter))
+  expect_success(expect_lint(file = "exclusions-test", exclusions = list(), checks = as.list(rep(msg, 6L)),
+                             linters = linter))
 
   expect_success(expect_lint("a=1; b=2", list(msg, msg), linter))
   expect_success(expect_lint("a=1; b=2", list(c(message = msg), c(message = msg)), linter))

--- a/tests/testthat/test-lint_package.R
+++ b/tests/testthat/test-lint_package.R
@@ -113,3 +113,25 @@ test_that(
   )
 })
 
+test_that(
+  "`lint_package` does not depend on path to pkg - with exclusions argument", {
+    # The test checks the results of lint_package when the excluded regions are
+    # given as an argument of the function and are specified using absolute and
+    # relative paths
+
+    pkg_path <- file.path("dummy_packages", "assignmentLinter")
+
+    # Create list of exclusions relative to the whole of `abc.R` and the first
+    # line of `jkl.R`
+    exclusions <- list(normalizePath(file.path(pkg_path, 'R/abc.R')),
+                       'R/jkl.R' = 1)
+
+    expected_lines <- c("mno = 789")
+    lints_from_outside <- lint_package(
+      pkg_path, linters = list(assignment_linter), exclusions = exclusions
+    )
+
+    expect_equal(
+      as.data.frame(lints_from_outside)[["line"]], expected_lines
+    )
+})


### PR DESCRIPTION
I would like to draw the attention to some changes that could be useful.

- Removed `test-exclusions` from `.lintr`.

- Changed arguments of one instance of `normalize_exclusions`, where part of the input was already in the form of absolute paths.

- Changed `normalize_exclusions` to prevent adding a prefix when the paths in the exclusions are absolute paths.